### PR TITLE
Add @daybrush/utils to package.json dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -181,10 +181,9 @@
       }
     },
     "@daybrush/utils": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@daybrush/utils/-/utils-0.10.1.tgz",
-      "integrity": "sha512-pKnlI3C+u/qgkhypQQT9G7YwEmBp+6XD5ZHzVCKtA0avuku//KGdLoIT6QL78aXI7ZPlJwY31t24+6xkxqdoJg==",
-      "dev": true
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@daybrush/utils/-/utils-1.6.0.tgz",
+      "integrity": "sha512-9MjMoOLl1U+l8lXByN3BbLZXf+mktoLyeb6t78Jz2WZ7LRldK0FNg8oW//9giO2hHCUyxS7LX6jS1hToGIfRWA=="
     },
     "@scena/event-emitter": {
       "version": "1.0.2",
@@ -420,6 +419,14 @@
       "dev": true,
       "requires": {
         "@daybrush/utils": "^0.10.0"
+      },
+      "dependencies": {
+        "@daybrush/utils": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/@daybrush/utils/-/utils-0.10.5.tgz",
+          "integrity": "sha512-VCPbgJgImkUmGHX33drZJh/5FYBhfSM+EFqlBY7fzKIahBGEemjYfninVSp9BdzqF9P2MyCh7R3hgxmySXLEzg==",
+          "dev": true
+        }
       }
     },
     "debug": {
@@ -909,6 +916,14 @@
         "@daybrush/utils": "^0.10.1",
         "args": "^5.0.1",
         "sync-exec": "^0.6.2"
+      },
+      "dependencies": {
+        "@daybrush/utils": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/@daybrush/utils/-/utils-0.10.5.tgz",
+          "integrity": "sha512-VCPbgJgImkUmGHX33drZJh/5FYBhfSM+EFqlBY7fzKIahBGEemjYfninVSp9BdzqF9P2MyCh7R3hgxmySXLEzg==",
+          "dev": true
+        }
       }
     },
     "query-string": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "homepage": "https://github.com/daybrush/dragscroll#readme",
   "dependencies": {
+    "@daybrush/utils": "1.6.0",
     "@scena/event-emitter": "^1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Explicitly adds the implicit dependency on "@daybrush/utils" to package.json. Should prevent having to write a `packageExtensions` entry for those using yarn 2+.

Fixes #1